### PR TITLE
ci: auto-trigger sourcery re-review on new commits

### DIFF
--- a/.github/workflows/sourcery-gate.yml
+++ b/.github/workflows/sourcery-gate.yml
@@ -1,19 +1,34 @@
 name: Sourcery Gate
 
 on:
+  pull_request:
+    types: [synchronize]
   pull_request_review:
     types: [submitted]
 
 permissions:
   statuses: write
+  pull-requests: write
 
 jobs:
   sourcery-gate:
     runs-on: ubuntu-latest
     name: Mark Sourcery review received
-    if: contains(github.event.review.user.login, 'sourcery-ai')
     steps:
+      - name: Request Sourcery re-review on new commits
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '@sourcery-ai review'
+            })
+
       - name: Post sourcery-reviewed status
+        if: github.event_name == 'pull_request_review' && contains(github.event.review.user.login, 'sourcery-ai')
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary

- Updates `sourcery-gate.yml` to listen for `pull_request: synchronize` events
- When new commits are pushed to a PR, automatically posts `@sourcery-ai review` as a comment to trigger a fresh Sourcery review
- `sourcery-reviewed` status is then posted by the existing review handler once Sourcery responds

This ensures Sourcery always reviews the latest changes rather than the `sourcery-reviewed` check going missing after a push.

## Test plan

- [ ] Push a new commit to an open PR and confirm a `@sourcery-ai review` comment is posted automatically
- [ ] Confirm Sourcery reviews and `sourcery-reviewed` status check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Automatically trigger Sourcery re-reviews on new commits to pull requests and gate status updates on Sourcery’s review responses.

CI:
- Update the Sourcery Gate workflow to listen for pull_request synchronize events and post an @sourcery-ai review comment on new commits.
- Restrict posting of the sourcery-reviewed status to Sourcery-authored pull request reviews and grant workflows permission to write pull request comments.