### PR TITLE
fix: add blank lines before ingredient tables in green juice recipe

### DIFF
--- a/_recipes/garden-green-juice-and-smoothie.md
+++ b/_recipes/garden-green-juice-and-smoothie.md
@@ -14,6 +14,7 @@ A fresh green juice paired with a creamy smoothie made from the leftover pulp â€
 ## Ingredients
 
 ### Juice
+
 | Ingredient | Quantity |
 |:-:|:-:|
 | Granny Smith Apple | 1 |
@@ -23,6 +24,7 @@ A fresh green juice paired with a creamy smoothie made from the leftover pulp â€
 | Lemon Juice | 1 tablespoon |
 
 ### Smoothie
+
 | Ingredient | Quantity |
 |:-:|:-:|
 | Green Juice Pulp | 2 cups |


### PR DESCRIPTION
## Summary

- Adds a blank line between each `###` subheading and its ingredient table
- Kramdown requires this blank line to parse tables correctly; without it they render as raw pipe-separated text

## Test plan

- [ ] Confirm ingredient tables render correctly on the recipe page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Add required blank lines before ingredient tables so the markdown engine parses and renders them as tables instead of raw text.