### PR TITLE
chore: add /add-recipe Claude Code skill

### DIFF
--- a/.claude/commands/add-recipe.md
+++ b/.claude/commands/add-recipe.md
@@ -19,9 +19,24 @@ If `$ARGUMENTS` doesn't include enough information, ask the user for:
 - Author (`pjt` unless specified otherwise)
 - A photo, if they have one (ask them to provide the file path, e.g. via `@/path/to/image.png`)
 
-### 2. Process the image (if provided)
+### 2. Derive the slug
 
-Images go in `assets/img/`. The slug is the recipe title lowercased with spaces replaced by hyphens.
+The slug is used for the filename, image files, branch name, and URL. Derive it from the recipe title:
+
+1. Lowercase the entire title
+2. Replace spaces with hyphens
+3. Remove or replace any character that is not a letter, digit, or hyphen:
+   - Ampersands (`&`) → omit (e.g. "Mac & Cheese" → `mac-cheese`)
+   - Apostrophes/quotes → omit (e.g. "Mom's Soup" → `moms-soup`)
+   - Commas, parentheses, slashes, and other punctuation → omit
+4. Collapse multiple consecutive hyphens into one
+5. Strip leading and trailing hyphens
+
+If the resulting slug would collide with an existing file in `_recipes/`, append a short disambiguator (e.g. `-v2`).
+
+### 3. Process the image (if provided)
+
+Images go in `assets/img/`.
 
 ```bash
 # Full-size JPEG
@@ -31,10 +46,11 @@ sips -s format jpeg <input> --out assets/img/<slug>.jpg
 sips -s format jpeg -z 400 300 <input> --out assets/img/<slug>-300x400.jpg
 ```
 
-### 3. Create the recipe file
+### 4. Create the recipe file
 
-Create `_recipes/<slug>.md`. Use this structure exactly:
+Create `_recipes/<slug>.md`.
 
+**With image:**
 ```markdown
 ---
 author: pjt
@@ -48,27 +64,70 @@ tags: [<Tag>]
 ---
 
 <One-sentence description of the recipe.>
+```
 
+**Without image** (omit the `image:` block entirely):
+```markdown
+---
+author: pjt
+title: <Title>
+categories: [<Category>]
+tags: [<Tag>]
+---
+
+<One-sentence description of the recipe.>
+```
+
+**Ingredients — single section** (no `###` heading needed):
+```markdown
 ## Ingredients
 
-**CRITICAL — Kramdown rule:** always put a blank line between a heading (`###`, `##`, etc.) and a table. Without it, the table renders as raw pipe text in the browser.
+| Ingredient | Quantity |
+|:-:|:-:|
+| <Ingredient> | <Amount> |
+```
 
-### <Section name, e.g. "Sauce"> (omit section heading if there's only one ingredient list)
+**Ingredients — multiple sections** (e.g. separate sauce and filling):
+```markdown
+## Ingredients
+
+### <Section Name>
 
 | Ingredient | Quantity |
 |:-:|:-:|
 | <Ingredient> | <Amount> |
 
+### <Section Name>
+
+| Ingredient | Quantity |
+|:-:|:-:|
+| <Ingredient> | <Amount> |
+```
+
+**CRITICAL — Kramdown rule:** always put a blank line between a heading (`###`, `##`, etc.) and a table. Without it, the table renders as raw pipe text in the browser.
+
+**Instructions — single section** (no `###` heading needed):
+```markdown
 ## Instructions
 
-### <Section name> (omit if only one section)
 1. Step one.
 2. Step two.
 ```
 
-If there is no image, omit the `image:` block entirely.
+**Instructions — multiple sections:**
+```markdown
+## Instructions
 
-### 4. Commit and open a PR
+### <Section Name>
+1. Step one.
+2. Step two.
+
+### <Section Name>
+1. Step one.
+2. Step two.
+```
+
+### 5. Commit and open a PR
 
 Use conventional commit format:
 

--- a/.claude/commands/add-recipe.md
+++ b/.claude/commands/add-recipe.md
@@ -1,0 +1,81 @@
+# Add a Recipe to the Family Cookbook
+
+Add a new recipe to the jain-taylor-family-cookbook Jekyll site, including image processing, correctly structured markdown, a conventional commit, and a PR ready for Sourcery review.
+
+## Arguments
+
+`$ARGUMENTS` — recipe title and/or details. If not provided, ask the user for the recipe name, ingredients, and instructions before proceeding.
+
+## Steps
+
+### 1. Gather recipe details
+
+If `$ARGUMENTS` doesn't include enough information, ask the user for:
+- Recipe title
+- Ingredients (can be a list; you'll structure them into a table)
+- Instructions (numbered steps)
+- Category (one of: Appetizers, Breakfast, Desserts, Drinks, Entrees, Miscellaneous, Seasonings, Soups, Side Dishes)
+- Tags (one or more of: Vegetarian, Vegan, Meat)
+- Author (`pjt` unless specified otherwise)
+- A photo, if they have one (ask them to provide the file path, e.g. via `@/path/to/image.png`)
+
+### 2. Process the image (if provided)
+
+Images go in `assets/img/`. The slug is the recipe title lowercased with spaces replaced by hyphens.
+
+```bash
+# Full-size JPEG
+sips -s format jpeg <input> --out assets/img/<slug>.jpg
+
+# Thumbnail — portrait 300×400 (note: sips -z takes height then width)
+sips -s format jpeg -z 400 300 <input> --out assets/img/<slug>-300x400.jpg
+```
+
+### 3. Create the recipe file
+
+Create `_recipes/<slug>.md`. Use this structure exactly:
+
+```markdown
+---
+author: pjt
+title: <Title>
+image:
+  path: /assets/img/<slug>.jpg
+  thumbnail: /assets/img/<slug>-300x400.jpg
+  caption: "<Short description of the image>"
+categories: [<Category>]
+tags: [<Tag>]
+---
+
+<One-sentence description of the recipe.>
+
+## Ingredients
+
+**CRITICAL — Kramdown rule:** always put a blank line between a heading (`###`, `##`, etc.) and a table. Without it, the table renders as raw pipe text in the browser.
+
+### <Section name, e.g. "Sauce"> (omit section heading if there's only one ingredient list)
+
+| Ingredient | Quantity |
+|:-:|:-:|
+| <Ingredient> | <Amount> |
+
+## Instructions
+
+### <Section name> (omit if only one section)
+1. Step one.
+2. Step two.
+```
+
+If there is no image, omit the `image:` block entirely.
+
+### 4. Commit and open a PR
+
+Use conventional commit format:
+
+```
+feat: add <recipe title> recipe
+```
+
+Branch name: `feat/add-<slug>`
+
+After pushing and opening the PR, monitor for the Sourcery review. When Sourcery comments, retrieve their "Prompt for AI Agents" section and address all feedback before requesting merge.


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/add-recipe.md` — a `/add-recipe` skill for Claude Code
- Encodes the full recipe-addition workflow: gather details, process images with `sips`, create correctly structured markdown (including the Kramdown blank-line-before-tables rule), commit, and open a PR

## Test plan

- [ ] Invoke `/add-recipe` in a new session and verify Claude follows the workflow without needing manual correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a Claude Code command for automating the recipe addition workflow to the family cookbook site.

New Features:
- Introduce an /add-recipe Claude Code skill that guides adding new recipes to the Jekyll-based family cookbook, including image handling and PR creation.

Enhancements:
- Document a standardized, step-by-step process for collecting recipe metadata, formatting markdown to comply with Kramdown, and preparing a conventional commit and pull request.