### PR TITLE
chore: add Claude Code rules for recipes and images

### DIFF
--- a/.claude/rules/images.md
+++ b/.claude/rules/images.md
@@ -1,0 +1,38 @@
+---
+paths:
+  - "assets/img/**"
+---
+
+# Recipe Image Rules
+
+## Required files per recipe
+
+Two image files per recipe, both JPEG:
+
+| File | Purpose |
+|:-:|:-:|
+| `assets/img/<slug>.jpg` | Full-size image |
+| `assets/img/<slug>-300x400.jpg` | Thumbnail (portrait 300×400) |
+
+The slug matches the recipe filename without the `.md` extension.
+
+## Processing with sips (macOS)
+
+Convert a source PNG or JPEG to the required files:
+
+```bash
+# Full-size JPEG
+sips -s format jpeg <source> --out assets/img/<slug>.jpg
+
+# Thumbnail — portrait 300×400 (note: -z takes height then width)
+sips -s format jpeg -z 400 300 <source> --out assets/img/<slug>-300x400.jpg
+```
+
+## Frontmatter reference
+
+```yaml
+image:
+  path: /assets/img/<slug>.jpg
+  thumbnail: /assets/img/<slug>-300x400.jpg
+  caption: "<Short description of the image>"
+```

--- a/.claude/rules/recipes.md
+++ b/.claude/rules/recipes.md
@@ -1,0 +1,60 @@
+---
+paths:
+  - "_recipes/**/*.md"
+---
+
+# Recipe File Rules
+
+## Frontmatter
+
+```yaml
+---
+author: pjt
+title: <Title Case Recipe Name>
+image:
+  path: /assets/img/<slug>.jpg
+  thumbnail: /assets/img/<slug>-300x400.jpg
+  caption: "<Short description of the image>"
+categories: [<Category>]
+tags: [<Tag>]
+---
+```
+
+Omit the `image:` block entirely if there is no photo.
+
+**Valid categories** (must match `_config.yml` exactly):
+Appetizers, Breakfast, Desserts, Drinks, Entrees, Miscellaneous, Seasonings, Side Dishes, Soups
+
+**Valid tags** (must match `_config.yml` exactly):
+Meat, Vegan, Vegetarian
+
+## Kramdown table rule
+
+Always put a blank line between a heading and a markdown table. Without it, Kramdown renders the table as raw pipe-separated text.
+
+**Correct:**
+```markdown
+### Juice
+
+| Ingredient | Quantity |
+|:-:|:-:|
+| Apple | 1 |
+```
+
+**Broken:**
+```markdown
+### Juice
+| Ingredient | Quantity |
+|:-:|:-:|
+| Apple | 1 |
+```
+
+This applies to every `##` and `###` heading that precedes a table, including multi-section recipes with separate ingredient tables per section.
+
+## File naming
+
+Filename must be the recipe title lowercased with spaces replaced by hyphens: `my-recipe-name.md`. This slug is also used for image filenames and the URL permalink.
+
+## Permalink pattern
+
+`/recipes/<category-lowercase>/<slug>/` — derived automatically by Jekyll from the frontmatter.

--- a/_config.yml
+++ b/_config.yml
@@ -70,5 +70,5 @@ footer_links:
   - title: GitHub
     url: https://github.com/patrick-andrew-jain-taylor
     icon: fab fa-github-square
-categories: [Appetizers, Breakfast, Desserts, Entrees, Miscellaneous, Seasonings, Soups, Side Dishes]
+categories: [Appetizers, Breakfast, Desserts, Drinks, Entrees, Miscellaneous, Seasonings, Side Dishes, Soups]
 tags: [Vegetarian, Vegan, Meat]


### PR DESCRIPTION
## Summary

- Adds `.claude/rules/recipes.md` — path-scoped to `_recipes/**/*.md`; encodes frontmatter schema, valid categories/tags, and the Kramdown blank-line-before-tables rule
- Adds `.claude/rules/images.md` — path-scoped to `assets/img/**`; encodes `sips` commands, file naming, and thumbnail dimensions
- Fixes `_config.yml`: registers `Drinks` as a valid category (was used by the green juice recipe but missing from the canonical list)

## Why commit these

Path-scoped rules are project conventions any contributor should follow, so they belong in source control alongside the code they govern. They only load into context when Claude works with matching files, keeping sessions lean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document and enforce project conventions for recipe content and images, and align site configuration with those conventions.

New Features:
- Add path-scoped Claude rules for recipe markdown files, including frontmatter schema, allowed categories/tags, table formatting, and naming/permalink conventions.
- Add path-scoped Claude rules for recipe images, including required file variants, processing commands, and frontmatter structure.

Enhancements:
- Update the Jekyll configuration to include Drinks as a valid category and keep the category list in sync with documented recipe rules.