### PR TITLE
ci: coalesce sourcery re-reviews to ease rate limiting

### DIFF
--- a/.claude/rules/recipes.md
+++ b/.claude/rules/recipes.md
@@ -68,3 +68,11 @@ Commits are linted with `@commitlint/config-conventional` (see `.github/workflow
 When publishing a recipe, after opening its pull request, subscribe to the PR's activity (`subscribe_pr_activity`) so review comments and CI failures are auto-handled until the PR is merged or closed. Do this for every recipe PR going forward.
 
 Once Sourcery has approved the PR (a "thumbs up" — an approving review, not just addressed comments) and CI is green, you have standing permission to merge the PR and then monitor the resulting GitHub Action to confirm the site builds successfully. Do not merge before Sourcery's approval.
+
+## Minimize pushes per PR
+
+Sourcery's free/open-source plan is rate-limited over a rolling 7-day window, and `sourcery-gate.yml` requests a fresh Sourcery review on every push (`synchronize`). Each push therefore consumes the rate limit, and once Sourcery is throttled it stops posting the required `sourcery-reviewed` status — blocking merges. To avoid this:
+
+* Assemble all changes locally and push **once** per PR rather than pushing each small commit as you go.
+* When addressing review feedback, batch the fixes into a single push.
+* Avoid force-push churn; prefer one final amend/rebase over repeated re-pushes.

--- a/.github/workflows/sourcery-gate.yml
+++ b/.github/workflows/sourcery-gate.yml
@@ -6,6 +6,14 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Coalesce bursts of rapid pushes so we only request one Sourcery re-review
+# per burst instead of one per push, easing Sourcery's rolling-window rate
+# limit. Keyed by event name so the review-trigger runs (pull_request) and the
+# status-posting runs (pull_request_review) never cancel each other.
+concurrency:
+  group: sourcery-gate-${{ github.event_name }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   statuses: write
   pull-requests: write


### PR DESCRIPTION
## Summary

Sourcery's free/open-source plan is rate-limited over a rolling 7-day window, and `sourcery-gate.yml` requests a fresh `@sourcery-ai review` on **every** push (`synchronize`). A burst of small commits / force-pushes therefore fires a review request per push, burning the limit — and once Sourcery is throttled it stops submitting reviews, so the required `sourcery-reviewed` status is never posted and merges get blocked (exactly what happened on #206).

## Changes

- **`sourcery-gate.yml`** — add a `concurrency` group with `cancel-in-progress: true`, keyed by `event_name` + PR number. Rapid successive pushes now collapse to a single review request instead of one per push. Keying on `event_name` keeps the review-trigger runs (`pull_request`) and the status-posting runs (`pull_request_review`) in separate groups so they never cancel each other.
- **`.claude/rules/recipes.md`** — document a "minimize pushes per PR" practice (assemble locally and push once, batch review fixes into one push, avoid force-push churn).

## Notes / trade-offs

`cancel-in-progress` only collapses pushes that land within the few seconds a run takes, so it catches true force-push bursts. The larger mitigation is the batching discipline now documented in the rules file. This change does not weaken the merge gate — `sourcery-reviewed` remains required.

## Test plan

- [ ] Push two commits in quick succession to a test PR and confirm only one `@sourcery-ai review` comment is posted (older run cancelled).
- [ ] Confirm a single Sourcery review still posts `sourcery-reviewed` and the PR can merge.

https://claude.ai/code/session_01PrZgKFBf7ig6vGtJJe5r7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrZgKFBf7ig6vGtJJe5r7y)_

## Summary by Sourcery

Coalesce rapid Sourcery review requests in CI to ease rate limiting and document push discipline to avoid exhausting Sourcery’s quota.

CI:
- Add a concurrency group to the Sourcery gate workflow so rapid successive pushes to a PR collapse into a single Sourcery re-review request.

Documentation:
- Document guidelines for minimizing pushes per PR to reduce Sourcery review rate-limit usage.