### PR TITLE
ci: add netlify config for pr deploy previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 /.idea/
 .DS_Store
+
+# Jekyll / Bundler build artifacts
+/_site/
+/.jekyll-cache/
+/.jekyll-metadata
+/.bundle/
+/vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,17 @@
+source "https://rubygems.org"
+
+# Match what GitHub Pages runs in production so Netlify (and local) builds
+# stay in lockstep with the live site at recipes.jaintaylor.family.
+# This bundle includes Jekyll, jekyll-remote-theme, and every plugin
+# referenced in _config.yml.
+gem "github-pages", group: :jekyll_plugins
+
+# Ruby 3.4 removed these from the standard library; pin them so builds keep
+# working on newer Netlify build images regardless of the Ruby version chosen.
+gem "csv"
+gem "base64"
+gem "bigdecimal"
+gem "logger"
+
+# Needed to run `bundle exec jekyll serve` locally on Ruby 3+.
+gem "webrick"

--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ plugins:
   - jekyll-sitemap
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-remote-theme # required to load remote_theme on non-GitHub-Pages builds (Netlify previews)
 # Collections
 collections:
   recipes:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,21 @@
+# Netlify config — used for per-PR Deploy Previews.
+# Production stays on GitHub Pages (recipes.jaintaylor.family); this site is
+# only a build target for previewing branches/PRs before they merge.
+
+[build]
+  command = "bundle exec jekyll build --trace"
+  publish = "_site"
+
+[build.environment]
+  # Pin a Ruby that's compatible with the github-pages gem. If this exact
+  # patch isn't on Netlify's image, bump it to a nearby 3.3.x in the logs.
+  RUBY_VERSION = "3.3.6"
+  # Keep analytics/comments from firing on preview builds.
+  JEKYLL_ENV = "development"
+
+# The real site is indexed via GitHub Pages. Tell crawlers not to index the
+# Netlify mirror or any deploy preview, so we never compete with production.
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Robots-Tag = "noindex"


### PR DESCRIPTION
## What & why

Production stays on **GitHub Pages** (`recipes.jaintaylor.family`), but legacy "deploy from a branch" Pages only ever builds `main` — so there's no way to preview a recipe before it's merged.

This PR makes the repo buildable by **Netlify**, which produces a unique **Deploy Preview** URL for every PR (e.g. `https://deploy-preview-NNN--<site>.netlify.app/`) and comments the link on the PR. Because Netlify serves each preview at its own subdomain root, the site's root-served layout (no `baseurl`) renders correctly with no path rewriting.

## Changes

- **`Gemfile`** — pins the `github-pages` gem so Netlify builds match the production Pages build exactly (same Jekyll + plugin versions). Includes Ruby 3.4 stdlib shims (`csv`, `base64`, `bigdecimal`, `logger`) and `webrick` for local `jekyll serve`.
- **`netlify.toml`** — `bundle exec jekyll build` → `_site`, pinned `RUBY_VERSION`, `JEKYLL_ENV=development` (keeps analytics/comments off previews), and a global `X-Robots-Tag: noindex` so the Netlify mirror/previews never compete with production in search.
- **`_config.yml`** — adds `jekyll-remote-theme` to `plugins` so the `so-simple` `remote_theme` resolves off GitHub Pages. (Harmless on Pages, where it's already enabled.)
- **`.gitignore`** — ignores Jekyll/Bundler build artifacts (`_site/`, `.jekyll-cache/`, `vendor/`, …).

## One-time setup required (after merge or on this branch)

This PR can't connect the repo to Netlify by itself — that needs an account authorization:

1. https://app.netlify.com/teams/patrick-andrew-taylor → **Add new site → Import an existing project → GitHub** → pick `jain-taylor-family-cookbook`.
2. Netlify auto-detects `netlify.toml`; just confirm. (No changes to the production domain — GitHub Pages keeps serving `recipes.jaintaylor.family`.)
3. Done. Every PR from then on gets a Deploy Preview link as a status check + comment.

## Notes
- First build pulls the `so-simple` theme via the GitHub API; if it ever hits an unauthenticated rate limit, add a `GITHUB_TOKEN` env var in Netlify.
- If `RUBY_VERSION = "3.3.6"` isn't on Netlify's build image, the log will say so — bump to a nearby `3.3.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Configure the site to support Netlify deploy previews for pull requests while keeping production on GitHub Pages.

New Features:
- Add Netlify configuration to build the Jekyll site and publish deploy previews for pull requests.

Enhancements:
- Enable the jekyll-remote-theme plugin in the Jekyll configuration so remote themes resolve outside GitHub Pages.
- Introduce a Gemfile that pins the github-pages gem and required Ruby libraries to keep local and Netlify builds aligned with production.

Build:
- Add netlify.toml to define the Netlify build command, Ruby version, environment, and noindex headers for preview deployments.