### PR TITLE
feat: rebrand as The Taylor Family Cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Pepper Paneer dish
 
+### Changed
+- Rebranded as The Taylor Family Cookbook; site moved to [recipes.taylors.family](https://recipes.taylors.family/) (old domain redirects).
+
 ## [0.4.0] - 2021-04-03
 ### Added
 - Additional authors added.
@@ -53,8 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic framework from [So Simple Jekyll Theme](https://github.com/mmistakes/so-simple-theme) used with authors and recipes.
 - CNAME added for [recipes.jaintaylor.family](https://recipes.jaintaylor.family/)
 
-[Unreleased]: https://github.com/patrick-andrew-jain-taylor/jain-taylor-family-cookbook/compare/v0.3.0...HEAD
-[0.4.0]: https://github.com/patrick-andrew-jain-taylor/jain-taylor-family-cookbook/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/patrick-andrew-jain-taylor/jain-taylor-family-cookbook/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/patrick-andrew-jain-taylor/jain-taylor-family-cookbook/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/patrick-andrew-jain-taylor/jain-taylor-family-cookbook/releases/tag/v0.1.0
+[Unreleased]: https://github.com/patrick-andrew-jain-taylor/taylor-family-cookbook/compare/v0.3.0...HEAD
+[0.4.0]: https://github.com/patrick-andrew-jain-taylor/taylor-family-cookbook/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/patrick-andrew-jain-taylor/taylor-family-cookbook/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/patrick-andrew-jain-taylor/taylor-family-cookbook/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/patrick-andrew-jain-taylor/taylor-family-cookbook/releases/tag/v0.1.0

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 remote_theme: "mmistakes/so-simple-theme@3.2.0"
 locale: "en-us"
-title: "The Jain-Taylor Family Cookbook"
+title: "The Taylor Family Cookbook"
 description: "Generations of Recipes, From GG to You and Me"
-url: "https://recipes.jaintaylor.family"
+url: "https://recipes.taylors.family"
 logo: "/assets/img/cookbook.jpg"
 date_format: "%B %-d, %Y"
 round-avatar: true

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,4 +9,4 @@
 - title: Search
   url: /search/
 - title: Github
-  url: https://github.com/patrick-andrew-jain-taylor/jain-taylor-family-cookbook
+  url: https://github.com/patrick-andrew-jain-taylor/taylor-family-cookbook

--- a/_recipes/artichoke-dip.md
+++ b/_recipes/artichoke-dip.md
@@ -9,7 +9,7 @@ categories: [Appetizers]
 tags: [Vegetarian]
 ---
 
-A vegetarian alternative to [Clam Dip](https://recipes.jaintaylor.family/recipes/appetizers/clam-dip/)
+A vegetarian alternative to [Clam Dip](https://recipes.taylors.family/recipes/appetizers/clam-dip/)
 
 ## Ingredients
 

--- a/_recipes/christmas-crepes.md
+++ b/_recipes/christmas-crepes.md
@@ -9,7 +9,7 @@ categories: [Breakfast]
 tags: [Vegetarian]
 ---
 
-A Jain-Taylor family Christmas tradition combining delicate crepes with both savory and sweet components. This recipe serves 2 people with a choice of two flavor profiles: savory with glazed tofu and Velveeta sauce, or sweet with berry compote, Nutella, and whipped cream.
+A Taylor family Christmas tradition combining delicate crepes with both savory and sweet components. This recipe serves 2 people with a choice of two flavor profiles: savory with glazed tofu and Velveeta sauce, or sweet with berry compote, Nutella, and whipped cream.
 
 ## Components
 

--- a/_recipes/mushroom-dip.md
+++ b/_recipes/mushroom-dip.md
@@ -9,7 +9,7 @@ categories: [Appetizers]
 tags: [Vegetarian]
 ---
 
-A vegetarian alternative to [Clam Dip](https://recipes.jaintaylor.family/recipes/appetizers/clam-dip/)
+A vegetarian alternative to [Clam Dip](https://recipes.taylors.family/recipes/appetizers/clam-dip/)
 
 ## Ingredients
 

--- a/_recipes/vegan-pernil-sandwich.md
+++ b/_recipes/vegan-pernil-sandwich.md
@@ -14,7 +14,7 @@ Inspired by [Sophie's Cuban Cuisine's](https://www.sophiescuban.com/) Pernil wit
 ## Ingredients
 
 - [Vegan Pernil](https://cooking.nytimes.com/recipes/1024877-vegan-jackfruit-pernil)[^1]
-- [Aji Verde (Green Sauce)](https://recipes.jaintaylor.family/recipes/miscellaneous/green-sauce/)[^2]
+- [Aji Verde (Green Sauce)](https://recipes.taylors.family/recipes/miscellaneous/green-sauce/)[^2]
 - [Quick-Pickled Red Onions](https://www.bonappetit.com/recipe/quick-pickled-onions)[^3]
 - [Goya Maduros (Fried Plantains)](https://www.goya.com/en/products/ripe-plantains)[^4]
 - Mayo

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 # Netlify config — used for per-PR Deploy Previews.
-# Production stays on GitHub Pages (recipes.jaintaylor.family); this site is
+# Production stays on GitHub Pages (recipes.taylors.family); this site is
 # only a build target for previewing branches/PRs before they merge.
 
 [build]


### PR DESCRIPTION
## Summary
- Rename the site from "The Jain-Taylor Family Cookbook" to "The Taylor Family Cookbook" in `_config.yml`, and point the canonical `url` at https://recipes.taylors.family (CNAME was already migrated).
- Update absolute recipe cross-links (clam dip, green sauce) and the `netlify.toml` comment from `recipes.jaintaylor.family` to `recipes.taylors.family`.
- Update the Christmas crepes intro from "A Jain-Taylor family Christmas tradition" to "A Taylor family Christmas tradition".
- Point GitHub links in `_data/navigation.yml` and the CHANGELOG compare links at the `taylor-family-cookbook` repo slug (repo rename to match; old URLs redirect).
- Add an Unreleased changelog entry for the rebrand.

Personal names are intentionally untouched: the LICENSE copyright line, `_data/authors.yml` author names, and the Jain-family credits in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rebrand the site and repository to The Taylor Family Cookbook and update URLs to the new recipes.taylors.family domain.

Enhancements:
- Update canonical site URL, internal recipe cross-links, navigation GitHub URL, Netlify comment, and changelog compare links to the new domain and repository slug.

Documentation:
- Update cookbook title references and Christmas crepes description to use the new Taylor family branding.