### PR TITLE
feat: credit Sadella Khana as jollof rice author

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -54,3 +54,5 @@ cdn:
 rsj:
   name: Renu (Sharma) Jain
   picture: "/assets/img/authors/rsj.jpg"
+sdk:
+  name: Sadella Khana

--- a/_recipes/jollof-rice.md
+++ b/_recipes/jollof-rice.md
@@ -1,5 +1,5 @@
 ---
-author: pjt
+author: sdk
 title: Jollof Rice
 image:
   path: /assets/img/jollof-rice.jpg
@@ -10,8 +10,8 @@ categories: [Entrees]
 tags: [Meat]
 ---
 
-An oven-baked Nigerian jollof rice, generously shared by a coworker via a
-cooking video[^1]. A blended pepper mix does double duty — a quarter of it
+An oven-baked Nigerian jollof rice, generously shared by Sadella Khana via
+her cooking video[^1]. A blended pepper mix does double duty — a quarter of it
 seasons the meat while it simmers, and the rest becomes the base of the stew.
 The rice then cooks in the oven using only the meat stock (no water!), sealed
 under plastic wrap and foil so it steams instead of burning.


### PR DESCRIPTION
Adds Sadella Khana to `_data/authors.yml` (key `sdk`) and switches the jollof rice recipe's author to her, so her byline card appears on the recipe. Also names her in the recipe intro.

No author photo yet — several existing authors (sc, dmc, cdn) also have text-only entries, and the theme handles that fine. Easy to add one later if she sends a picture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Credit Sadella Khana as the author of the jollof rice recipe and add her to the site’s authors list.

New Features:
- Add Sadella Khana as a new author entry in the global authors data.

Enhancements:
- Update the jollof rice recipe to attribute authorship and intro text to Sadella Khana so her byline appears on the page.