### PR TITLE
fix: remove dangling footnote ref from mac & cheese heading

### DIFF
--- a/_recipes/mac-and-cheese.md
+++ b/_recipes/mac-and-cheese.md
@@ -11,7 +11,7 @@ tags: [Vegetarian]
 
 Inspired by the Mac and Cheese at [Michael Jordan's Steakhouse](https://www.michaeljordansteakhouse.com/) in Chicago, this mac is to die for!
 
-## Ingredients[^1]
+## Ingredients
 
 | Ingredient | Quantity |
 |:-:|:-:|


### PR DESCRIPTION
The `[^1]` reference in the Ingredients heading had no matching footnote definition, so kramdown rendered the raw marker as literal text on the live page: https://recipes.taylors.family/recipes/entrees/sides/mac-and-cheese/

Sibling recipes (green-sauce, pizza-sauce) use this pattern with a `[^1]: [Source: ...]` definition; this one was never filled in. Since the intro sentence already links to Michael Jordan's Steakhouse, the marker is removed rather than inventing a source.

Checked all other recipes for dangling/orphaned footnotes — this was the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix display of the mac-and-cheese recipe ingredients heading by removing a dangling footnote reference.