### PR TITLE
fix: update links and names after account rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic framework from [So Simple Jekyll Theme](https://github.com/mmistakes/so-simple-theme) used with authors and recipes.
 - CNAME added for [recipes.jaintaylor.family](https://recipes.jaintaylor.family/)
 
-[Unreleased]: https://github.com/patrick-andrew-jain-taylor/taylor-family-cookbook/compare/v0.3.0...HEAD
-[0.4.0]: https://github.com/patrick-andrew-jain-taylor/taylor-family-cookbook/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/patrick-andrew-jain-taylor/taylor-family-cookbook/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/patrick-andrew-jain-taylor/taylor-family-cookbook/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/patrick-andrew-jain-taylor/taylor-family-cookbook/releases/tag/v0.1.0
+[Unreleased]: https://github.com/patrick-andrew-taylor/taylor-family-cookbook/compare/v0.3.0...HEAD
+[0.4.0]: https://github.com/patrick-andrew-taylor/taylor-family-cookbook/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/patrick-andrew-taylor/taylor-family-cookbook/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/patrick-andrew-taylor/taylor-family-cookbook/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/patrick-andrew-taylor/taylor-family-cookbook/releases/tag/v0.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # Match what GitHub Pages runs in production so Netlify (and local) builds
-# stay in lockstep with the live site at recipes.jaintaylor.family.
+# stay in lockstep with the live site at recipes.taylors.family.
 # This bundle includes Jekyll, jekyll-remote-theme, and every plugin
 # referenced in _config.yml.
 gem "github-pages", group: :jekyll_plugins

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Patrick Jain-Taylor
+Copyright (c) 2021 Patrick Taylor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/_config.yml
+++ b/_config.yml
@@ -62,9 +62,6 @@ include:
   - LICENSE.md
   - _pages
 footer_links:
-  - title: Twitter
-    url: https://twitter.com/pjaintaylor
-    icon: fab fa-twitter-square
   - title: LinkedIn
     url: https://www.linkedin.com/in/patrickandrewtaylor/
     icon: fab fa-linkedin

--- a/_config.yml
+++ b/_config.yml
@@ -66,10 +66,10 @@ footer_links:
     url: https://twitter.com/pjaintaylor
     icon: fab fa-twitter-square
   - title: LinkedIn
-    url: https://linkedin.com/in/pjaintaylor
+    url: https://www.linkedin.com/in/patrickandrewtaylor/
     icon: fab fa-linkedin
   - title: GitHub
-    url: https://github.com/patrick-andrew-jain-taylor
+    url: https://github.com/patrick-andrew-taylor
     icon: fab fa-github-square
 categories: [Appetizers, Breakfast, Desserts, Drinks, Entrees, Miscellaneous, Seasonings, Side Dishes, Soups]
 tags: [Vegetarian, Vegan, Meat]

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -7,10 +7,10 @@ pjt:
       url: https://twitter.com/pjaintaylor
       icon: fab fa-twitter-square
     - title: LinkedIn
-      url: https://linkedin.com/in/pjaintaylor
+      url: https://www.linkedin.com/in/patrickandrewtaylor/
       icon: fab fa-linkedin
     - title: GitHub
-      url: https://github.com/patrick-andrew-jain-taylor
+      url: https://github.com/patrick-andrew-taylor
       icon: fab fa-github-square
 dmt:
   name: Denise (Zimmerman) Taylor

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,11 +1,7 @@
 pjt:
   name: Patrick Taylor
   picture: "/assets/img/authors/pjt.jpeg"
-  twitter: pjaintaylor
   links:
-    - title: Twitter
-      url: https://twitter.com/pjaintaylor
-      icon: fab fa-twitter-square
     - title: LinkedIn
       url: https://www.linkedin.com/in/patrickandrewtaylor/
       icon: fab fa-linkedin

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,4 +9,4 @@
 - title: Search
   url: /search/
 - title: Github
-  url: https://github.com/patrick-andrew-jain-taylor/taylor-family-cookbook
+  url: https://github.com/patrick-andrew-taylor/taylor-family-cookbook


### PR DESCRIPTION
## Summary

The GitHub account renamed `patrick-andrew-jain-taylor` → `patrick-andrew-taylor`, this repo renamed to `taylor-family-cookbook`, and the LinkedIn profile moved to `/in/patrickandrewtaylor`. This sweeps the repo's own references:

- **`_config.yml`** + **`_data/authors.yml`** — footer/author GitHub links point at the new profile (profile URLs get no redirect from GitHub); LinkedIn links updated to the new slug; Twitter links and the author `twitter` meta field removed — that account is no longer maintained.
- **`_data/navigation.yml`** + **`CHANGELOG.md` link definitions** — now point at `patrick-andrew-taylor/taylor-family-cookbook`, the repo's true current path (they previously went through owner/repo redirects).
- **`Gemfile`** — comment references the current production domain `recipes.taylors.family`.
- **`LICENSE.md`** — copyright holder updated to Patrick Taylor.

Historical CHANGELOG entry text (e.g. the original `jaintaylor.family` CNAME note) is left as-is — it records what happened at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sWhd45D7cckXzsvYFJtFY