### PR TITLE
fix: correct sadella's last name and jollof origin

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -42,5 +42,5 @@ jfz:
 cdn:
   name: Colleen (Dorsey) Needham
 sdk:
-  name: Sadella Khana
+  name: Sadella Khama
   picture: "/assets/img/authors/sdk.jpg"

--- a/_recipes/jollof-rice.md
+++ b/_recipes/jollof-rice.md
@@ -10,7 +10,7 @@ categories: [Entrees]
 tags: [Meat]
 ---
 
-An oven-baked Nigerian jollof rice, generously shared by Sadella Khana via
+An oven-baked Ghanaian jollof rice, generously shared by Sadella Khama via
 her cooking video[^1]. A blended pepper mix does double duty — a quarter of it
 seasons the meat while it simmers, and the rest becomes the base of the stew.
 The rice then cooks in the oven using only the meat stock (no water!), sealed


### PR DESCRIPTION
Two corrections requested by Sadella:

- **Last name:** "Sadella Khana" → "Sadella Khama" in `_data/authors.yml` and in the jollof rice recipe's intro. Her author key (`sdk`) and photo filename are unchanged.
- **Recipe origin:** The intro of `_recipes/jollof-rice.md` now describes the dish as Ghanaian jollof rice rather than Nigerian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECr59xUY72idoTE68kYj26

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECr59xUY72idoTE68kYj26)_

## Summary by Sourcery

Correct author metadata and recipe description for the jollof rice post.

Bug Fixes:
- Fix Sadella's last name in the authors data file and jollof rice recipe intro.
- Correct the jollof rice recipe intro to describe the dish as Ghanaian rather than Nigerian.